### PR TITLE
Add Cypress CI workflow

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -1,0 +1,21 @@
+name: Cypress Tests
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+
+jobs:
+  cypress-run:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - name: Install dependencies
+        run: npm ci
+      - name: Run Cypress tests
+        run: npx cypress run


### PR DESCRIPTION
## Summary
- add Github workflow to run Cypress tests on pushes and PRs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68782fe022bc8329aed0798921f3340a