### PR TITLE
Add requirements file and pin httpx

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -16,6 +16,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install . pytest pytest-asyncio httpx
+          pip install .
+          pip install -r requirements-test.txt
       - name: Run tests
         run: pytest -q

--- a/README.md
+++ b/README.md
@@ -62,3 +62,14 @@ The `settings` mutation type allows creating, updating and deleting items in the
 
 Runtime configuration is stored in `config/config.json`. If the file does not exist, it will be created with default values on first run.
 
+
+## Testing
+
+Install the test dependencies and run the suite with:
+
+```bash
+pip install -r requirements-test.txt
+pytest
+```
+
+The requirements file pins `httpx<0.25` and includes the `pytest-asyncio` plugin used by the async tests.

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,0 +1,3 @@
+pytest
+pytest-asyncio
+httpx<0.25


### PR DESCRIPTION
## Summary
- add `requirements-test.txt` for local and CI testing
- document the new requirements file and pinned dependencies in the README
- update CI workflow to install from the requirements file

## Testing
- `pip install -r requirements-test.txt`
- `pip install .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6879f7ed98a88329a7425e934243a514